### PR TITLE
Fix typo. Make `API` capitalisation consistent

### DIFF
--- a/12-managing-access/README.md
+++ b/12-managing-access/README.md
@@ -218,7 +218,7 @@ RECORDS_REST_ENDPOINTS = {
 """REST API for my-site."""
 ```
 
-4. Go to the api search page `https://127.0.0.1:5000/api/records/?prettyprint=1` and check that it displays only the records owned by the current user
+4. Go to the API search page `https://127.0.0.1:5000/api/records/?prettyprint=1` and check that it displays only the records owned by the current user
 
 5. Go to the UI search page `https://127.0.0.1:5000/search?page=1&size=20&q=` and check that it displays only the records owned by the current user
 
@@ -389,7 +389,7 @@ RECORDS_REST_ENDPOINTS = {
 6. Visit `https://127.0.0.1:5000/search?page=1&size=20&q=` and `https://127.0.0.1:5000/api/records/?prettyprint=1` as manager user and check if all the records are listed.
 
 
-### Explicit access per action type - additional excersize
+### Explicit access per action type - additional exercise
 
 1. Implement access management for the record having in mind the structure below
 


### PR DESCRIPTION
Just a couple of quick fixes in the 12th lesson