### PR TITLE
Extend vagrant disk size to 20GB (fixes #91)

### DIFF
--- a/00-prerequisites/Vagrantfile
+++ b/00-prerequisites/Vagrantfile
@@ -1,3 +1,8 @@
+# Ensure that vagrant-disksize is installed to proceed (allows resizing the vagrant box disk)
+unless Vagrant.has_plugin?("vagrant-disksize")
+    raise  Vagrant::Errors::VagrantError.new, "vagrant-disksize plugin is missing. Please install it using 'vagrant plugin install vagrant-disksize' and retry 'vagrant up'"
+end
+
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/bionic64"
 

--- a/00-prerequisites/Vagrantfile
+++ b/00-prerequisites/Vagrantfile
@@ -1,6 +1,9 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/bionic64"
 
+  # Extend the disk from the default size
+  config.disksize.size = '20GB'
+
   # Enable GUI
   config.vm.provider "virtualbox" do |v|
     v.memory = 4096

--- a/12-managing-access/README.md
+++ b/12-managing-access/README.md
@@ -218,7 +218,7 @@ RECORDS_REST_ENDPOINTS = {
 """REST API for my-site."""
 ```
 
-4. Go to the api search page `https://127.0.0.1:5000/api/records/?prettyprint=1` and check that it displays only the records owned by the current user
+4. Go to the API search page `https://127.0.0.1:5000/api/records/?prettyprint=1` and check that it displays only the records owned by the current user
 
 5. Go to the UI search page `https://127.0.0.1:5000/search?page=1&size=20&q=` and check that it displays only the records owned by the current user
 
@@ -389,7 +389,7 @@ RECORDS_REST_ENDPOINTS = {
 6. Visit `https://127.0.0.1:5000/search?page=1&size=20&q=` and `https://127.0.0.1:5000/api/records/?prettyprint=1` as manager user and check if all the records are listed.
 
 
-### Explicit access per action type - additional excersize
+### Explicit access per action type - additional exercise
 
 1. Implement access management for the record having in mind the structure below
 


### PR DESCRIPTION
Sets the VM to have a 20GB volume (instead of the 10 GB one in case the virtualisation provisioner is VirtualBox). Fixes #91 . 

Requires an additional Vagrant plugin to reach a consistent behaviour on the disk size of the created VM.

Vagrantfile now checks if this plugin installed and suggests how to do that in case it's not found.

The value 20 GB is based on the fact that after running "docker-compose -f docker-compose.full.yml up -d" the /vagrant mount point reaches ~14 GB so there's still some wiggle room for other stuff. 15 GB could be good too.

```
vagrant@ubuntu-bionic:~/src/my-site$ df -h
Filesystem      Size  Used Avail Use% Mounted on
udev            2.0G     0  2.0G   0% /dev
tmpfs           395M  1.4M  394M   1% /run
/dev/sda1        49G  9.4G   39G  20% /
tmpfs           2.0G     0  2.0G   0% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           2.0G     0  2.0G   0% /sys/fs/cgroup
vagrant         176G  163G   13G  93% /vagrant
tmpfs           395M     0  395M   0% /run/user/1000
vagrant@ubuntu-bionic:~/src/my-site$ 

```