### PR TITLE
Update README.md [Celery 5.0]

### DIFF
--- a/04-running-invenio/README.md
+++ b/04-running-invenio/README.md
@@ -250,7 +250,7 @@ Another integral part of an Invenio instance is background Celery workers. To
 run these you have use the `celery` command:
 
 ```bash
-(my-site) $ celery worker -A invenio_app.celery -l INFO
+(my-site) $ celery -A invenio_app.celery worker -l INFO
 
  -------------- celery@invenio v4.2.1 (windowlicker)
 ---- **** -----


### PR DESCRIPTION
Since Celery 5.0 release the support of the "-A" was removed so the command `(my-site) $ celery worker -A invenio_app.celery -l INFO` is not working anymore... From my understanding, its replacement is  `celery -A invenio_app.celery worker -l INFO`