### PR TITLE
Updated uwsgi python plugin and node versions

### DIFF
--- a/00-prerequisites/bootstrap.sh
+++ b/00-prerequisites/bootstrap.sh
@@ -6,7 +6,7 @@ user=${1:-vagrant}
 apt-get update
 apt-get install -y apt-utils software-properties-common apt-transport-https \
     gnupg-agent ca-certificates git curl wget unzip python3-dev python3-pip \
-    libcairo2-dev fonts-dejavu libfreetype6-dev uwsgi-plugin-python \
+    libcairo2-dev fonts-dejavu libfreetype6-dev uwsgi-plugin-python3 \
     default-jdk xvfb libxi6 libgconf-2-4
 
 # Set "python3" as the default "python"
@@ -14,7 +14,7 @@ update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
 # Install NodeJS/npm
-curl -sL https://deb.nodesource.com/setup_10.x | bash -
+curl -sL https://deb.nodesource.com/setup_14.x | bash -
 apt-get install -y nodejs
 
 # Install docker


### PR DESCRIPTION
When setting up the environment for training, dependencies `uwsgi-plugin-python` and `node` are currently outdated when installed using script `/training/00-prerequisites/bootstrap.sh`.

Since the app requires `python 3.6+`, dependency `uwsgi-plugin-python` must be upgraded to `uwsgi-plugin-python3` in order to be compatible with `python 3`. 
Check [ubuntu releases](https://packages.ubuntu.com/search?keywords=uwsgi-plugin-python) and debian for [python 2](https://packages.debian.org/stretch/uwsgi-plugin-python) and [python 3](https://packages.debian.org/search?keywords=uwsgi-plugin-python3)

Additionally, `node` is currently being installed using version `10` while version `14+` is required. This is also mentioned in issue https://github.com/inveniosoftware/training/issues/107

