### PR TITLE
Cookiecutter invenio's version set to master

### DIFF
--- a/01-getting-started/README.md
+++ b/01-getting-started/README.md
@@ -25,7 +25,7 @@ use: Ctrl+Shift+V (paste), Ctrl+Shift+C (copy), Ctrl+Shift+X (cut).
 Scaffold the skeleton for your first Invenio instance:
 
 ```bash
-cookiecutter gh:inveniosoftware/cookiecutter-invenio-instance -c v3.4 --no-input
+cookiecutter gh:inveniosoftware/cookiecutter-invenio-instance -c master --no-input
 ```
 
 ## Step 4: Install

--- a/start-from.sh
+++ b/start-from.sh
@@ -32,7 +32,7 @@ cd "$invenio_src_folder"
 
 # Bootstrap Invenio instance
 echo "Boostrapping Invenio on $invenio_instance_folder."
-cookiecutter gh:inveniosoftware/cookiecutter-invenio-instance -c v3.4 --no-input
+cookiecutter gh:inveniosoftware/cookiecutter-invenio-instance -c master --no-input
 
 # Reinstalling appliation with preivious steps solutions
 cp -R "$invenio_training_folder/$exercise_tutorial_folder/solution/my-site/*" "$invenio_instance_folder"


### PR DESCRIPTION
This PR changes instructions on scaffolding `invenio` instance during training. Previous version (v.3.4.) was missing dependencies after building with webpack, which yielded errors such as https://github.com/inveniosoftware/training/issues/97