### PR TITLE
Fix 'start-from.sh' script

### DIFF
--- a/05-customizing-invenio/solution/my-site/my_site/config.py
+++ b/05-customizing-invenio/solution/my-site/my_site/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2019 CERN.
+# Copyright (C) 2022 CERN.
 #
 # My site is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
@@ -13,9 +13,10 @@ You overwrite and set instance-specific configuration by either:
 - Environment variables: ``APP_<variable name>``
 """
 
-from __future__ import absolute_import, print_function
-
 from datetime import timedelta
+
+from invenio_app.config import APP_DEFAULT_SECURE_HEADERS
+from invenio_previewer.config import PREVIEWER_PREFERENCE as BASE_PREFERENCE
 
 
 def _(x):
@@ -42,7 +43,7 @@ I18N_LANGUAGES = [
 # Base templates
 # ==============
 #: Global base template.
-BASE_TEMPLATE = 'my_site/page.html'
+BASE_TEMPLATE = 'invenio_theme/page.html'
 #: Cover page base template (used for e.g. login/sign-up).
 COVER_TEMPLATE = 'invenio_theme/page_cover.html'
 #: Footer base template.
@@ -54,7 +55,9 @@ SETTINGS_TEMPLATE = 'invenio_theme/page_settings.html'
 
 # Theme configuration
 # ===================
-#: Site name
+#: The Invenio theme.
+APP_THEME = ['semantic-ui']
+#: Site name.
 THEME_SITENAME = _('My site')
 #: Use default frontpage.
 THEME_FRONTPAGE = True
@@ -145,6 +148,11 @@ APP_ALLOWED_HOSTS = ['my-site.com', 'localhost', '127.0.0.1']
 # =======
 OAISERVER_ID_PREFIX = 'oai:my-site.com:'
 
+# Previewers
+# ==========
+#: Include IIIF preview for images.
+PREVIEWER_PREFERENCE = ['iiif_image'] + BASE_PREFERENCE
+
 # Debug
 # =====
 # Flask-DebugToolbar is by default enabled when the application is running in
@@ -153,3 +161,12 @@ OAISERVER_ID_PREFIX = 'oai:my-site.com:'
 
 #: Switches off incept of redirects by Flask-DebugToolbar.
 DEBUG_TB_INTERCEPT_REDIRECTS = False
+
+# Configures Content Security Policy for PDF Previewer
+# Remove it if you are not using PDF Previewer
+APP_DEFAULT_SECURE_HEADERS['content_security_policy'] = {
+    'default-src': ["'self'", "'unsafe-inline'"],
+    'object-src': ["'none'"],
+    'style-src': ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+    'font-src': ["'self'", "data:", "https://fonts.gstatic.com"],
+}

--- a/07-data-models-new-field/solution/my-site/my_site/config.py
+++ b/07-data-models-new-field/solution/my-site/my_site/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2019 CERN.
+# Copyright (C) 2022 CERN.
 #
 # My site is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
@@ -13,9 +13,10 @@ You overwrite and set instance-specific configuration by either:
 - Environment variables: ``APP_<variable name>``
 """
 
-from __future__ import absolute_import, print_function
-
 from datetime import timedelta
+
+from invenio_app.config import APP_DEFAULT_SECURE_HEADERS
+from invenio_previewer.config import PREVIEWER_PREFERENCE as BASE_PREFERENCE
 
 
 def _(x):
@@ -42,7 +43,7 @@ I18N_LANGUAGES = [
 # Base templates
 # ==============
 #: Global base template.
-BASE_TEMPLATE = 'my_site/page.html'
+BASE_TEMPLATE = 'invenio_theme/page.html'
 #: Cover page base template (used for e.g. login/sign-up).
 COVER_TEMPLATE = 'invenio_theme/page_cover.html'
 #: Footer base template.
@@ -54,7 +55,9 @@ SETTINGS_TEMPLATE = 'invenio_theme/page_settings.html'
 
 # Theme configuration
 # ===================
-#: Site name
+#: The Invenio theme.
+APP_THEME = ['semantic-ui']
+#: Site name.
 THEME_SITENAME = _('My site')
 #: Use default frontpage.
 THEME_FRONTPAGE = True
@@ -145,6 +148,11 @@ APP_ALLOWED_HOSTS = ['my-site.com', 'localhost', '127.0.0.1']
 # =======
 OAISERVER_ID_PREFIX = 'oai:my-site.com:'
 
+# Previewers
+# ==========
+#: Include IIIF preview for images.
+PREVIEWER_PREFERENCE = ['iiif_image'] + BASE_PREFERENCE
+
 # Debug
 # =====
 # Flask-DebugToolbar is by default enabled when the application is running in
@@ -153,3 +161,12 @@ OAISERVER_ID_PREFIX = 'oai:my-site.com:'
 
 #: Switches off incept of redirects by Flask-DebugToolbar.
 DEBUG_TB_INTERCEPT_REDIRECTS = False
+
+# Configures Content Security Policy for PDF Previewer
+# Remove it if you are not using PDF Previewer
+APP_DEFAULT_SECURE_HEADERS['content_security_policy'] = {
+    'default-src': ["'self'", "'unsafe-inline'"],
+    'object-src': ["'none'"],
+    'style-src': ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+    'font-src': ["'self'", "data:", "https://fonts.gstatic.com"],
+}

--- a/08-data-models-from-scratch/solution/my-site/my_site/config.py
+++ b/08-data-models-from-scratch/solution/my-site/my_site/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2019 CERN.
+# Copyright (C) 2022 CERN.
 #
 # My site is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
@@ -13,9 +13,10 @@ You overwrite and set instance-specific configuration by either:
 - Environment variables: ``APP_<variable name>``
 """
 
-from __future__ import absolute_import, print_function
-
 from datetime import timedelta
+
+from invenio_app.config import APP_DEFAULT_SECURE_HEADERS
+from invenio_previewer.config import PREVIEWER_PREFERENCE as BASE_PREFERENCE
 
 
 def _(x):
@@ -42,7 +43,7 @@ I18N_LANGUAGES = [
 # Base templates
 # ==============
 #: Global base template.
-BASE_TEMPLATE = 'my_site/page.html'
+BASE_TEMPLATE = 'invenio_theme/page.html'
 #: Cover page base template (used for e.g. login/sign-up).
 COVER_TEMPLATE = 'invenio_theme/page_cover.html'
 #: Footer base template.
@@ -54,7 +55,9 @@ SETTINGS_TEMPLATE = 'invenio_theme/page_settings.html'
 
 # Theme configuration
 # ===================
-#: Site name
+#: The Invenio theme.
+APP_THEME = ['semantic-ui']
+#: Site name.
 THEME_SITENAME = _('My site')
 #: Use default frontpage.
 THEME_FRONTPAGE = True
@@ -145,6 +148,11 @@ APP_ALLOWED_HOSTS = ['my-site.com', 'localhost', '127.0.0.1']
 # =======
 OAISERVER_ID_PREFIX = 'oai:my-site.com:'
 
+# Previewers
+# ==========
+#: Include IIIF preview for images.
+PREVIEWER_PREFERENCE = ['iiif_image'] + BASE_PREFERENCE
+
 # Debug
 # =====
 # Flask-DebugToolbar is by default enabled when the application is running in
@@ -153,3 +161,12 @@ OAISERVER_ID_PREFIX = 'oai:my-site.com:'
 
 #: Switches off incept of redirects by Flask-DebugToolbar.
 DEBUG_TB_INTERCEPT_REDIRECTS = False
+
+# Configures Content Security Policy for PDF Previewer
+# Remove it if you are not using PDF Previewer
+APP_DEFAULT_SECURE_HEADERS['content_security_policy'] = {
+    'default-src': ["'self'", "'unsafe-inline'"],
+    'object-src': ["'none'"],
+    'style-src': ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+    'font-src': ["'self'", "data:", "https://fonts.gstatic.com"],
+}

--- a/09-deposit-form/solution/my-site/my_site/config.py
+++ b/09-deposit-form/solution/my-site/my_site/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2019 CERN.
+# Copyright (C) 2022 CERN.
 #
 # My site is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
@@ -13,9 +13,10 @@ You overwrite and set instance-specific configuration by either:
 - Environment variables: ``APP_<variable name>``
 """
 
-from __future__ import absolute_import, print_function
-
 from datetime import timedelta
+
+from invenio_app.config import APP_DEFAULT_SECURE_HEADERS
+from invenio_previewer.config import PREVIEWER_PREFERENCE as BASE_PREFERENCE
 
 
 def _(x):
@@ -42,7 +43,7 @@ I18N_LANGUAGES = [
 # Base templates
 # ==============
 #: Global base template.
-BASE_TEMPLATE = 'my_site/page.html'
+BASE_TEMPLATE = 'invenio_theme/page.html'
 #: Cover page base template (used for e.g. login/sign-up).
 COVER_TEMPLATE = 'invenio_theme/page_cover.html'
 #: Footer base template.
@@ -54,7 +55,9 @@ SETTINGS_TEMPLATE = 'invenio_theme/page_settings.html'
 
 # Theme configuration
 # ===================
-#: Site name
+#: The Invenio theme.
+APP_THEME = ['semantic-ui']
+#: Site name.
 THEME_SITENAME = _('My site')
 #: Use default frontpage.
 THEME_FRONTPAGE = True
@@ -145,6 +148,11 @@ APP_ALLOWED_HOSTS = ['my-site.com', 'localhost', '127.0.0.1']
 # =======
 OAISERVER_ID_PREFIX = 'oai:my-site.com:'
 
+# Previewers
+# ==========
+#: Include IIIF preview for images.
+PREVIEWER_PREFERENCE = ['iiif_image'] + BASE_PREFERENCE
+
 # Debug
 # =====
 # Flask-DebugToolbar is by default enabled when the application is running in
@@ -153,3 +161,12 @@ OAISERVER_ID_PREFIX = 'oai:my-site.com:'
 
 #: Switches off incept of redirects by Flask-DebugToolbar.
 DEBUG_TB_INTERCEPT_REDIRECTS = False
+
+# Configures Content Security Policy for PDF Previewer
+# Remove it if you are not using PDF Previewer
+APP_DEFAULT_SECURE_HEADERS['content_security_policy'] = {
+    'default-src': ["'self'", "'unsafe-inline'"],
+    'object-src': ["'none'"],
+    'style-src': ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+    'font-src': ["'self'", "data:", "https://fonts.gstatic.com"],
+}

--- a/10-indexing-records/solution/my-site/my_site/config.py
+++ b/10-indexing-records/solution/my-site/my_site/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2019 CERN.
+# Copyright (C) 2022 CERN.
 #
 # My site is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
@@ -13,9 +13,10 @@ You overwrite and set instance-specific configuration by either:
 - Environment variables: ``APP_<variable name>``
 """
 
-from __future__ import absolute_import, print_function
-
 from datetime import timedelta
+
+from invenio_app.config import APP_DEFAULT_SECURE_HEADERS
+from invenio_previewer.config import PREVIEWER_PREFERENCE as BASE_PREFERENCE
 
 
 def _(x):
@@ -42,7 +43,7 @@ I18N_LANGUAGES = [
 # Base templates
 # ==============
 #: Global base template.
-BASE_TEMPLATE = 'my_site/page.html'
+BASE_TEMPLATE = 'invenio_theme/page.html'
 #: Cover page base template (used for e.g. login/sign-up).
 COVER_TEMPLATE = 'invenio_theme/page_cover.html'
 #: Footer base template.
@@ -54,7 +55,9 @@ SETTINGS_TEMPLATE = 'invenio_theme/page_settings.html'
 
 # Theme configuration
 # ===================
-#: Site name
+#: The Invenio theme.
+APP_THEME = ['semantic-ui']
+#: Site name.
 THEME_SITENAME = _('My site')
 #: Use default frontpage.
 THEME_FRONTPAGE = True
@@ -145,6 +148,11 @@ APP_ALLOWED_HOSTS = ['my-site.com', 'localhost', '127.0.0.1']
 # =======
 OAISERVER_ID_PREFIX = 'oai:my-site.com:'
 
+# Previewers
+# ==========
+#: Include IIIF preview for images.
+PREVIEWER_PREFERENCE = ['iiif_image'] + BASE_PREFERENCE
+
 # Debug
 # =====
 # Flask-DebugToolbar is by default enabled when the application is running in
@@ -153,3 +161,12 @@ OAISERVER_ID_PREFIX = 'oai:my-site.com:'
 
 #: Switches off incept of redirects by Flask-DebugToolbar.
 DEBUG_TB_INTERCEPT_REDIRECTS = False
+
+# Configures Content Security Policy for PDF Previewer
+# Remove it if you are not using PDF Previewer
+APP_DEFAULT_SECURE_HEADERS['content_security_policy'] = {
+    'default-src': ["'self'", "'unsafe-inline'"],
+    'object-src': ["'none'"],
+    'style-src': ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+    'font-src': ["'self'", "data:", "https://fonts.gstatic.com"],
+}

--- a/11-linking-records/solution/my-site/my_site/config.py
+++ b/11-linking-records/solution/my-site/my_site/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2019 CERN.
+# Copyright (C) 2022 CERN.
 #
 # My site is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
@@ -13,9 +13,10 @@ You overwrite and set instance-specific configuration by either:
 - Environment variables: ``APP_<variable name>``
 """
 
-from __future__ import absolute_import, print_function
-
 from datetime import timedelta
+
+from invenio_app.config import APP_DEFAULT_SECURE_HEADERS
+from invenio_previewer.config import PREVIEWER_PREFERENCE as BASE_PREFERENCE
 
 
 def _(x):
@@ -42,7 +43,7 @@ I18N_LANGUAGES = [
 # Base templates
 # ==============
 #: Global base template.
-BASE_TEMPLATE = 'my_site/page.html'
+BASE_TEMPLATE = 'invenio_theme/page.html'
 #: Cover page base template (used for e.g. login/sign-up).
 COVER_TEMPLATE = 'invenio_theme/page_cover.html'
 #: Footer base template.
@@ -54,7 +55,9 @@ SETTINGS_TEMPLATE = 'invenio_theme/page_settings.html'
 
 # Theme configuration
 # ===================
-#: Site name
+#: The Invenio theme.
+APP_THEME = ['semantic-ui']
+#: Site name.
 THEME_SITENAME = _('My site')
 #: Use default frontpage.
 THEME_FRONTPAGE = True
@@ -145,6 +148,11 @@ APP_ALLOWED_HOSTS = ['my-site.com', 'localhost', '127.0.0.1']
 # =======
 OAISERVER_ID_PREFIX = 'oai:my-site.com:'
 
+# Previewers
+# ==========
+#: Include IIIF preview for images.
+PREVIEWER_PREFERENCE = ['iiif_image'] + BASE_PREFERENCE
+
 # Debug
 # =====
 # Flask-DebugToolbar is by default enabled when the application is running in
@@ -153,3 +161,12 @@ OAISERVER_ID_PREFIX = 'oai:my-site.com:'
 
 #: Switches off incept of redirects by Flask-DebugToolbar.
 DEBUG_TB_INTERCEPT_REDIRECTS = False
+
+# Configures Content Security Policy for PDF Previewer
+# Remove it if you are not using PDF Previewer
+APP_DEFAULT_SECURE_HEADERS['content_security_policy'] = {
+    'default-src': ["'self'", "'unsafe-inline'"],
+    'object-src': ["'none'"],
+    'style-src': ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+    'font-src': ["'self'", "data:", "https://fonts.gstatic.com"],
+}

--- a/12-managing-access/solution/my-site/my_site/config.py
+++ b/12-managing-access/solution/my-site/my_site/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2019 CERN.
+# Copyright (C) 2022 CERN.
 #
 # My site is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
@@ -13,9 +13,10 @@ You overwrite and set instance-specific configuration by either:
 - Environment variables: ``APP_<variable name>``
 """
 
-from __future__ import absolute_import, print_function
-
 from datetime import timedelta
+
+from invenio_app.config import APP_DEFAULT_SECURE_HEADERS
+from invenio_previewer.config import PREVIEWER_PREFERENCE as BASE_PREFERENCE
 
 
 def _(x):
@@ -42,7 +43,7 @@ I18N_LANGUAGES = [
 # Base templates
 # ==============
 #: Global base template.
-BASE_TEMPLATE = 'my_site/page.html'
+BASE_TEMPLATE = 'invenio_theme/page.html'
 #: Cover page base template (used for e.g. login/sign-up).
 COVER_TEMPLATE = 'invenio_theme/page_cover.html'
 #: Footer base template.
@@ -54,7 +55,9 @@ SETTINGS_TEMPLATE = 'invenio_theme/page_settings.html'
 
 # Theme configuration
 # ===================
-#: Site name
+#: The Invenio theme.
+APP_THEME = ['semantic-ui']
+#: Site name.
 THEME_SITENAME = _('My site')
 #: Use default frontpage.
 THEME_FRONTPAGE = True
@@ -145,6 +148,11 @@ APP_ALLOWED_HOSTS = ['my-site.com', 'localhost', '127.0.0.1']
 # =======
 OAISERVER_ID_PREFIX = 'oai:my-site.com:'
 
+# Previewers
+# ==========
+#: Include IIIF preview for images.
+PREVIEWER_PREFERENCE = ['iiif_image'] + BASE_PREFERENCE
+
 # Debug
 # =====
 # Flask-DebugToolbar is by default enabled when the application is running in
@@ -153,3 +161,12 @@ OAISERVER_ID_PREFIX = 'oai:my-site.com:'
 
 #: Switches off incept of redirects by Flask-DebugToolbar.
 DEBUG_TB_INTERCEPT_REDIRECTS = False
+
+# Configures Content Security Policy for PDF Previewer
+# Remove it if you are not using PDF Previewer
+APP_DEFAULT_SECURE_HEADERS['content_security_policy'] = {
+    'default-src': ["'self'", "'unsafe-inline'"],
+    'object-src': ["'none'"],
+    'style-src': ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+    'font-src': ["'self'", "data:", "https://fonts.gstatic.com"],
+}

--- a/start-from.sh
+++ b/start-from.sh
@@ -35,7 +35,7 @@ echo "Boostrapping Invenio on $invenio_instance_folder."
 cookiecutter gh:inveniosoftware/cookiecutter-invenio-instance -c v3.4 --no-input
 
 # Reinstalling appliation with preivious steps solutions
-cp -R "$invenio_training_folder/$exercise_tutorial_folder/solution/my-site/*" "$invenio_instance_folder"
+cp -R $invenio_training_folder/$exercise_tutorial_folder/solution/my-site/* "$invenio_instance_folder"
 echo "Reinstalling application."
 cd "$invenio_instance_folder"
 pipenv run pip install -e .


### PR DESCRIPTION
This PR fixes several issues from script `start-from.sh`, namely:

- Script's copy command yielded an error `directory does not exist` when using double quotes and wildcard `*`
- `solution` folders inside individual sections contained outdated `config.py` files. Yielded errors due to miss-configuration of the application.

Note: new `config.py` files was retrieved from [cookiecutter-invenio-instance](https://github.com/inveniosoftware/cookiecutter-invenio-instance/blob/55645e9b56db0f52ae0235efa68c72bf173c1d40/%7B%7Bcookiecutter.project_shortname%7D%7D/%7B%7Bcookiecutter.package_name%7D%7D/config.py) . 